### PR TITLE
Added private route component

### DIFF
--- a/src/components/PrivateRoute.js
+++ b/src/components/PrivateRoute.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Route, Redirect } from 'react-router-dom';
+
+
+const PrivateRoute = ({ component: Component, ...rest }) => {
+
+  const token = window.localStorage.getItem('token');
+  return (
+    <Route
+      {...rest}
+      render={props => {
+        if (token) {
+          return <Component {...props} />;
+        } else {
+          return <Redirect to="/login" />;
+        }
+      }}
+    />
+  );
+};
+
+export default PrivateRoute;


### PR DESCRIPTION
Added privateroute component. It takes the same props as the normal route component but redirects the user to login if there is no token. Once login endpoint is working, replace any auth-required routes with privateroute.